### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Normalize `actions/checkout` v5 → v6 to match the other Platzio repos.

Only the CI action is bumped — the chart's `platzio/*` image tags and `Chart.yaml` `version`/`appVersion` are **release-managed** and intentionally left untouched (the external `popen2/postgres-backup-s3` sidecar pin is also unchanged here). Part of the pre-release dependency refresh ahead of the next beta.

https://claude.ai/code/session_012x3qrx2pZ4HtbhJPB6W5Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_012x3qrx2pZ4HtbhJPB6W5Zv)_