### PR TITLE
Guard chart releases against missing images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,22 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
+      - name: Verify referenced images exist on Docker Hub
+        run: |
+          set -euo pipefail
+          values=charts/platzio/values.yaml
+          # Every image under .images (backend, frontend, helm/base) is tied to
+          # the release and must already be published before we ship the chart.
+          images=$(yq '.images[] | .repository + ":" + .tag' "$values" | tr -d '"')
+          for image in $images; do
+            echo "Checking docker.io/${image} ..."
+            if ! docker buildx imagetools inspect "docker.io/${image}" >/dev/null 2>&1; then
+              echo "::error::docker.io/${image} not found on Docker Hub — refusing to publish the chart"
+              exit 1
+            fi
+            echo "  found"
+          done
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     outputs:
       images: ${{ steps.list.outputs.images }}
     steps:
-      - name: Checkout
+      - name: 📥 Checkout
         uses: actions/checkout@v6
 
-      - name: List chart images
+      - name: 📋 List chart images
         id: list
         run: |
           set -euo pipefail
@@ -30,7 +30,7 @@ jobs:
       matrix:
         image: ${{ fromJson(needs.list-images.outputs.images) }}
     steps:
-      - name: Verify ${{ matrix.image }} exists on Docker Hub
+      - name: 🔍 Verify ${{ matrix.image }} exists on Docker Hub
         run: |
           if ! docker buildx imagetools inspect "docker.io/${{ matrix.image }}" >/dev/null 2>&1; then
             echo "::error::docker.io/${{ matrix.image }} not found on Docker Hub — refusing to publish the chart"
@@ -41,20 +41,20 @@ jobs:
     needs: verify-images
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: 📥 Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Configure Git
+      - name: ⚙️ Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
+      - name: ⎈ Install Helm
         uses: azure/setup-helm@v4
 
-      - name: Run chart-releaser
+      - name: 🚀 Run chart-releaser
         uses: helm/chart-releaser-action@v1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,39 @@ on:
       - main
 
 jobs:
+  list-images:
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.list.outputs.images }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: List chart images
+        id: list
+        run: |
+          set -euo pipefail
+          # Every image under .images (backend, frontend, helm/base) is tied to
+          # the release and must already be published before we ship the chart.
+          images=$(yq -o=json -I=0 '[.images[] | .repository + ":" + .tag]' charts/platzio/values.yaml)
+          echo "images=$images" >> "$GITHUB_OUTPUT"
+
+  verify-images:
+    needs: list-images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ${{ fromJson(needs.list-images.outputs.images) }}
+    steps:
+      - name: Verify ${{ matrix.image }} exists on Docker Hub
+        run: |
+          if ! docker buildx imagetools inspect "docker.io/${{ matrix.image }}" >/dev/null 2>&1; then
+            echo "::error::docker.io/${{ matrix.image }} not found on Docker Hub — refusing to publish the chart"
+            exit 1
+          fi
+
   release:
+    needs: verify-images
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,22 +53,6 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v4
-
-      - name: Verify referenced images exist on Docker Hub
-        run: |
-          set -euo pipefail
-          values=charts/platzio/values.yaml
-          # Every image under .images (backend, frontend, helm/base) is tied to
-          # the release and must already be published before we ship the chart.
-          images=$(yq '.images[] | .repository + ":" + .tag' "$values" | tr -d '"')
-          for image in $images; do
-            echo "Checking docker.io/${image} ..."
-            if ! docker buildx imagetools inspect "docker.io/${image}" >/dev/null 2>&1; then
-              echo "::error::docker.io/${image} not found on Docker Hub — refusing to publish the chart"
-              exit 1
-            fi
-            echo "  found"
-          done
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1


### PR DESCRIPTION
## Background

ArtifactHub was failing with:

```
error scanning image platzio/backend:v0.6.3: image not found (package platzio:0.6.3)
```

**Root cause:** chart `0.6.3` was published pointing at `platzio/backend:v0.6.3`, but that image was never pushed to Docker Hub — its backend release build failed at the time (mid-Alpine-migration) while the git tag and chart shipped anyway. The team moved on to `0.6.4`, leaving `0.6.3` permanently broken in the index, so ArtifactHub kept re-scanning a nonexistent image. (The version was also broken for end users — `helm install --version 0.6.3` would `ImagePullBackOff`.)

The immediate error was already cleared by removing the `0.6.3` entry from `index.yaml` on the `gh-pages` branch (separate, out-of-band fix).

## This PR — prevent recurrence

Adds a guard to the release workflow so a chart referencing an unpublished image can never reach the index again:

- **`list-images`** reads the image refs (`.images[]` → `repository:tag`) from `values.yaml`.
- **`verify-images`** fan-outs over them in a matrix and fails if any tag isn't present on Docker Hub (`docker buildx imagetools inspect`).
- **`release`** now `needs: verify-images`, so `chart-releaser` only runs once every referenced image resolves.

The matrix is dynamic, so it auto-covers `backend`, `frontend`, and the base image (`platzio/base`) — and anything added later under `.images`.

https://claude.ai/code/session_01VAfZxZTEehFNfABXAixZVd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAfZxZTEehFNfABXAixZVd)_