### PR TITLE
Set least-privilege permissions on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   list-images:
     runs-on: ubuntu-latest
@@ -40,6 +43,8 @@ jobs:
   release:
     needs: verify-images
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

CodeQL (`actions/missing-workflow-permissions`) flagged `release.yml` — added in #8 — for not declaring `GITHUB_TOKEN` permissions. Without an explicit `permissions:` block the workflow runs with the repository's default token scopes, which is broader than needed.

## Fix

Apply least privilege:

- **Top level:** `permissions: contents: read` — the default for all jobs (`list-images`, `verify-images` only read).
- **`release` job:** elevated to `contents: write`, the only thing it needs so `chart-releaser` can create GitHub releases and push the updated `index.yaml` to `gh-pages`.

```yaml
permissions:
  contents: read

jobs:
  ...
  release:
    permissions:
      contents: write
```

No behavior change for the happy path; just removes the CodeQL alert and tightens the token.

https://claude.ai/code/session_01VAfZxZTEehFNfABXAixZVd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAfZxZTEehFNfABXAixZVd)_